### PR TITLE
Corrected condition for missing argument

### DIFF
--- a/render.sh
+++ b/render.sh
@@ -2,7 +2,7 @@
 # generate Dockerfile from template with build settings
 
 # init stuff
-if [ -n $0 ]; then
+if [ -z $1 ]; then
   printf "no directory provided\n\n"
   echo "Usage: sh render.sh <DIRECTORY>"
   exit 2


### PR DESCRIPTION
Condition in render.sh script now checks for missing path argument.