### PR TITLE
render.sh: fix check for missing directory name and fix shellcheck warnings

### DIFF
--- a/render.sh
+++ b/render.sh
@@ -7,7 +7,7 @@ if [ $# -ne 1 ]; then
   echo "Usage: sh render.sh <DIRECTORY>"
   exit 2
 fi
-SCRIPT_DIR=$(dirname $(readlink -f $0))
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 ENV_DIR=${1-SCRIPT_DIR}
 ENV_FILE="${ENV_DIR}/.docker_build"
 
@@ -22,9 +22,9 @@ render(){
 }
 
 # main
-while read ARG
+while read -r ARG
 do
   SED_ARG="${SED_ARG} $(render)"
-done < $ENV_FILE
+done < "$ENV_FILE"
 
-sed -r "${SED_ARG}" ${SCRIPT_DIR}/Dockerfile.template > ${ENV_DIR}/Dockerfile
+sed -r "${SED_ARG}" "${SCRIPT_DIR}/Dockerfile.template" > "${ENV_DIR}/Dockerfile"

--- a/render.sh
+++ b/render.sh
@@ -2,7 +2,7 @@
 # generate Dockerfile from template with build settings
 
 # init stuff
-if [ -n $0 ]; then
+if [ $# -ne 1 ]; then
   printf "no directory provided\n\n"
   echo "Usage: sh render.sh <DIRECTORY>"
   exit 2


### PR DESCRIPTION
the old check didn't work correctly and caused the script to abort even
when there was a directory supplied

when editing the render.sh file i also fixed the warnings reported by the shellcheck linter.